### PR TITLE
Replace suffix sourceMaps in "task styles"

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,7 +71,13 @@ gulp.task('styles', () => {
                 cascade: false,
             })
         )
-        .pipe(sourceMaps.write(config.maps.dist))
+        .pipe(
+          $.sourcemaps.write(config.maps.dist, {
+            mapFile: function(mapFilePath) {
+              return mapFilePath.replace('.css.map', '.min.map');
+            }
+          })
+        )
         .pipe(
             rename({
                 basename: 'main',


### PR DESCRIPTION
Great repo Ignacio, I'm learning a lot with your gulpfile.js,
This modification solve the problem with the css source maps, **gulp-rename** fault 😤

Regards!
